### PR TITLE
Added basic error reporting

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE ViewPatterns      #-}
 
 module Main where
 
@@ -14,7 +14,7 @@ data Input = Input
   } deriving (Show, Eq)
 
 inputUncons :: Input -> Maybe (Char, Input)
-inputUncons (Input _ []) = Nothing
+inputUncons (Input _ [])       = Nothing
 inputUncons (Input loc (x:xs)) = Just (x, Input (loc + 1) xs)
 
 data JsonValue
@@ -184,7 +184,7 @@ parseFile :: FilePath -> Parser a -> IO (Either ParserError a)
 parseFile fileName parser = do
   input <- readFile fileName
   case runParser parser $ Input 0 input of
-    Left e -> return $ Left e
+    Left e       -> return $ Left e
     Right (_, x) -> return $ Right x
 
 main :: IO ()

--- a/Main.hs
+++ b/Main.hs
@@ -78,15 +78,13 @@ charP x = Parser f
 stringP :: String -> Parser String
 stringP str =
   Parser $ \input ->
-    let result = runParser (traverse charP str) input
-     in case result of
-          Left _ ->
-            Left $
-            ParserError
-              (inputLoc input)
-              ("Expected \"" ++
-               str ++ "\", but found \"" ++ inputStr input ++ "\"")
-          _ -> result
+    case runParser (traverse charP str) input of
+      Left _ ->
+        Left $
+        ParserError
+          (inputLoc input)
+          ("Expected \"" ++ str ++ "\", but found \"" ++ inputStr input ++ "\"")
+      result -> result
 
 jsonBool :: Parser JsonValue
 jsonBool = jsonTrue <|> jsonFalse

--- a/Main.hs
+++ b/Main.hs
@@ -123,8 +123,9 @@ decimalLiteral = (readDecimalPart <$>
                   pure (0, 0)
   where readExponent '+' = read
         readExponent '-' = negate . read
+        -- This should never occur:
         readExponent ch  = error $ ch : " was passed into readExponent, which expects either '+' or '-'"
-        
+
         readDecimalPart digits expnt = (read digits * 10**(-offset), expnt)
           where offset = fromIntegral (length digits)
 

--- a/Main.hs
+++ b/Main.hs
@@ -4,7 +4,6 @@ module Main where
 
 import           Control.Applicative
 import           Data.Char
-import           Data.Semigroup
 import           Numeric
 import           System.Exit
 
@@ -73,14 +72,14 @@ charP x = Parser f
   where
     f loc (y:ys)
       | y == x = Right (loc+1, ys, x)
-      | otherwise = Left $ KnownError (loc, "Expected '" <> [x] <> "', but found " <> [y])
-    f loc [] = Left $ KnownError (loc, "Expected '" <> [x] <> "', but reached end of string")
+      | otherwise = Left $ KnownError (loc, "Expected '" ++ [x] ++ "', but found " ++ [y])
+    f loc [] = Left $ KnownError (loc, "Expected '" ++ [x] ++ "', but reached end of string")
 
 stringP :: String -> Parser String
 stringP str = Parser $ \loc input ->
   let result = runParserWithLoc (traverse charP str) loc input in
   case result of
-    Left (KnownError _) -> Left $ KnownError (loc, "Expected \"" <> str <> "\", but found \"" <> input <> "\"")
+    Left (KnownError _) -> Left $ KnownError (loc, "Expected \"" ++ str ++ "\", but found \"" ++ input ++ "\"")
     _                   -> result
 
 jsonBool :: Parser JsonValue
@@ -101,8 +100,8 @@ parseIf desc f =
     case input of
       y:ys
         | f y       -> Right (loc+1, ys, y)
-        | otherwise -> Left $ KnownError (loc, "Expected " <> desc <> ", but found '" <> [y] <> "'")
-      [] -> Left $ KnownError (loc, "Expected " <> desc <> ", but reached end of string")
+        | otherwise -> Left $ KnownError (loc, "Expected " ++ desc ++ ", but found '" ++ [y] ++ "'")
+      [] -> Left $ KnownError (loc, "Expected " ++ desc ++ ", but reached end of string")
 
 {-
 A diagram explaining the logic behind the functions
@@ -208,19 +207,19 @@ main = do
   putStrLn testJsonText
   case runParser jsonValue testJsonText of
     Right (_, input, actualJsonAst) -> do
-      putStrLn ("[INFO] Parsed as: " <> show actualJsonAst)
-      putStrLn ("[INFO] Remaining input (codes): " <> show (map ord input))
+      putStrLn ("[INFO] Parsed as: " ++ show actualJsonAst)
+      putStrLn ("[INFO] Remaining input (codes): " ++ show (map ord input))
       if actualJsonAst == expectedJsonAst
         then putStrLn "[SUCCESS] Parser produced expected result."
         else do
           putStrLn
-            ("[ERROR] Parser produced unexpected result. Expected result was: " <>
+            ("[ERROR] Parser produced unexpected result. Expected result was: " ++
              show expectedJsonAst)
           exitFailure
     Left (KnownError (loc, msg)) -> do
-      putStrLn $ "[ERROR] Parser failed at character " <>
-                 (show loc) <>
-                 ": " <>
+      putStrLn $ "[ERROR] Parser failed at character " ++
+                 (show loc) ++
+                 ": " ++
                  msg
       exitFailure
     Left UnknownError -> do

--- a/Main.hs
+++ b/Main.hs
@@ -57,7 +57,7 @@ instance Alternative Parser where
 -- ONLY IF the error message from the Parser indicates that none of the input was read in successfully.
 (<?>) :: Parser a -> String -> Parser a
 (Parser p) <?> defaultMsg = Parser $ \loc input ->
-  p loc input <|> (Left $ KnownError (loc, defaultMsg))
+  p loc input <|> Left (KnownError (loc, defaultMsg))
 
 jsonNull :: Parser JsonValue
 jsonNull = JsonNull <$ stringP "null"

--- a/Main.hs
+++ b/Main.hs
@@ -109,22 +109,24 @@ decimalLiteral, nonNegativeLiteral, and doubleLiteral
 can be found on page 12 of
 http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf
 -}
+
+data Sign = Positive | Negative
+
 decimalLiteral :: Parser (Double, Integer)
-decimalLiteral = (readDecimalPart <$>
+decimalLiteral = readDecimalPart <$>
                   ((charP '.' *> spanP1 "digit" isDigit) <|>
                    pure "0")
                   <*>
                   (((charP 'e' <|> charP 'E') *>
                     (readExponent <$>
-                     ((charP '+' <|> charP '-') <|> pure '+') <*>
+                     (((Positive <$ charP '+') <|>
+                       (Negative <$ charP '-')) <|>
+                      pure Positive) <*>
                      spanP1 "digit" isDigit))
                    <|>
-                   pure 0)) <|>
-                  pure (0, 0)
-  where readExponent '+' = read
-        readExponent '-' = negate . read
-        -- This should never occur:
-        readExponent ch  = error $ ch : " was passed into readExponent, which expects either '+' or '-'"
+                   pure 0)
+  where readExponent Positive = read
+        readExponent Negative = negate . read
 
         readDecimalPart digits expnt = (read digits * 10**(-offset), expnt)
           where offset = fromIntegral (length digits)

--- a/Main.hs
+++ b/Main.hs
@@ -72,7 +72,7 @@ charP x = Parser f
   where
     f loc (y:ys)
       | y == x = Right (loc+1, ys, x)
-      | otherwise = Left $ KnownError (loc, "Expected '" ++ [x] ++ "', but found " ++ [y])
+      | otherwise = Left $ KnownError (loc, "Expected '" ++ [x] ++ "', but found '" ++ [y] ++ "'")
     f loc [] = Left $ KnownError (loc, "Expected '" ++ [x] ++ "', but reached end of string")
 
 stringP :: String -> Parser String


### PR DESCRIPTION
In this pull request, I added some basic error reporting, where, if `jsonValue` is unable to parse the given String, then it reports an error saying how many characters it had read in from the String when it encountered the problem, what it was expecting at that character, and what it actually found. For right now, the error reporting is pretty basic, as only `charP`, `stringP`, and `parseIf` actually report error messages. Here is an example:

<pre>
*Main> runParser jsonValue "1e-s"
Right (1,"e-s",JsonNumber 1.0)
*Main> runParser jsonValue "[1e-s]"
Left (KnownError (2,"Expected ']', but found 'e'"))
</pre>

In the first command, the `jsonValue` successfully parses the number `1` and then leaves the `e-s` alone because that exponent part is invalid. However, when we run `jsonValue` on an array containing `1e-s`, it says we expected a `]` when they found the `e`. Arguably, it should actually say that the exponent part of the number is invalid, but I think this will require some more complex error handling.

Also, as shown above, I report the number of characters the parser has read in so far. However, I had trouble figuring out how to get the number of characters that `reads` had parsed, since `jsonNumber` was implemented using `reads`. (One way to do this was to subtract the length of the whole string by the length of the unparsed input that `reads` returned, but this solution is O(n) where n is the length of the string, which I think is pretty inefficient and clunky.) Therefore, I rewrote `jsonNumber` based off [the JSON Data Interchange Syntax](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf), so that it could use `charP`, `parseIf`, and `spanP`, which makes it easier to update the number of characters read in so far.