### PR TITLE
Use Map instead of a list of tuple for JsonObject

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -5,9 +5,9 @@ module Main where
 
 import           Control.Applicative
 import           Data.Char
+import           Data.Map.Strict     hiding (empty)
 import           Numeric
 import           System.Exit
-import           Data.Map.Strict hiding (empty)
 
 data Input = Input
   { inputLoc :: Int


### PR DESCRIPTION
Import `Data.Map.Strict` and use `Map` instead `[(String, JsonValue)]` for the `JsonObject`.

As a side effect, duplicate keys are handled in `jsonObject` by `fromList` with the same behavior as JavaScript, i.e. "If the list contains more than one value for the same key, the last value for the key is retained."