### PR TITLE
Fix jsonNumber bug

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -5,6 +5,7 @@ module Main where
 
 import           Control.Applicative
 import           Data.Char
+import           Data.Foldable
 import           Numeric
 import           System.Exit
 
@@ -142,8 +143,7 @@ doubleLiteral =
     integerP = zeroP <|> unsignedPositiveIntegerP
     zeroP = stringP "0"
     unsignedPositiveIntegerP = (:) <$> nonZeroDigitP <*> many digit
-    nonZeroDigitP = choice . fmap charP $ ("123456789" :: [Char])
-    choice = foldr (<|>) empty
+    nonZeroDigitP = asum . fmap charP $ ("123456789" :: String)
     digits = some digit
     digit = parseIf "digit" isDigit
     minus = (-1) <$ charP '-'
@@ -227,8 +227,8 @@ parseInput :: Input -> Either ParserError JsonValue
 parseInput i = do
   result <- runParser jsonValue i
   case result of
-    ((Input _ ""), v) -> Right v
-    ((Input loc str), _) -> Left . ParserError loc $ "unexpected string remaining: " <> str
+    (Input _ "", v) -> Right v
+    (Input loc str, _) -> Left . ParserError loc $ "unexpected string remaining: " <> str
 
 -- | Apply parser to content of file
 parseFile :: FilePath                 -- File path to parse

--- a/Main.hs
+++ b/Main.hs
@@ -227,7 +227,7 @@ parseInput :: Input -> Either ParserError JsonValue
 parseInput i = do
   result <- runParser jsonValue i
   case result of
-    ((Input _ ""), jsonValue) -> Right jsonValue
+    ((Input _ ""), v) -> Right v
     ((Input loc str), _) -> Left . ParserError loc $ "unexpected string remaining: " <> str
 
 -- | Apply parser to content of file

--- a/Main.hs
+++ b/Main.hs
@@ -224,10 +224,11 @@ jsonValue =
 
 -- | Apply parser to an input, fails if anything's left in the input
 parseInput :: Input -> Either ParserError JsonValue
-parseInput i = case runParser jsonValue i of
-  Left e -> Left e
-  Right ((Input _ ""), jsonValue) -> Right jsonValue
-  Right ((Input loc str), _) -> Left . ParserError loc $ "unexpected string remaining: " <> str
+parseInput i = do
+  result <- runParser jsonValue i
+  case result of
+    ((Input _ ""), jsonValue) -> Right jsonValue
+    ((Input loc str), _) -> Left . ParserError loc $ "unexpected string remaining: " <> str
 
 -- | Apply parser to content of file
 parseFile :: FilePath                 -- File path to parse


### PR DESCRIPTION
First of all, thanks @tsoding for your awesome youtube videos, really enjoyed it and learnt quite a few things from you. 

And here goes the story:

I added a little helper function for my ghci convenience:

```haskell
-- | Apply parser to an input, fails if anything's left in the input
parseInput :: Input -> Either ParserError JsonValue
parseInput i = do
  result <- runParser jsonValue i
  case result of
    (Input _ "", v) -> Right v
    (Input loc str, _) -> Left . ParserError loc $ "unexpected string remaining: " <> str
```

And when I ran your original code, I found something interesting:

```
*Main > parseInput . Input 0 $ "001"
Right (JsonNumber 1.0)
```

Obviously it's because of our most intelligent `read` function ¯\\_(ツ)_/¯ .

After the PR changes it now becomes:

```
*Main > parseInput . Input 0 $ "001"
Left (ParserError 1 "unexpected string remaining: 01")
```

Sorry for the multiple commits to fix nits and make CI happy, feel free to squash merge. 

Comments and suggestions welcome :)